### PR TITLE
feat: add SubType filtering and IDExact matching artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,6 @@ Configure custom naming patterns for resources that need special mapping logic. 
 - Names are composite values (e.g., `solution_name(workspace_name)`)
 - You need to match resources by ID patterns rather than exact names
 - Resources are nested and need hierarchical matching
-- Working with `azapi_resource` types that need subtype-specific matching
 
 **Exact Name Matching:**
 ```yaml
@@ -354,13 +353,8 @@ nameFormats:
       - "name"
 ```
 
-**SubType-Aware Matching (for azapi_resource):**
+**SubType-Aware Matching:**
 
-For `azapi_resource` types, you can specify matching rules based on the Azure resource SubType. The tool applies name formats with deterministic precedence:
-
-1. **Exact SubType match**: `nameFormat.Type == resource.SubType`
-2. **Type+SubType match**: `nameFormat.Type == resource.Type && nameFormat.SubType == resource.SubType`
-3. **Type-only match**: `nameFormat.Type == resource.Type` (fallback)
 
 ```yaml
 nameFormats:

--- a/analyzer/mapping.go
+++ b/analyzer/mapping.go
@@ -79,14 +79,9 @@ func (mappingClient *MappingClient) Map() {
 	destroyBlocks := []types.DestroyBlock{}
 	for _, finalMappedResource := range finalMappedResources {
 		if finalMappedResource.ActionType == types.ActionTypeUse && finalMappedResource.Type == types.MappedResourceTypeTerraform {
-			resourceID := finalMappedResource.ResourceID
-			if finalMappedResource.ResourceAPIVersion != "" {
-				resourceID = fmt.Sprintf("%s?api-version=%s", resourceID, finalMappedResource.ResourceAPIVersion)
-			}
-
 			importBlock := types.ImportBlock{
 				To: finalMappedResource.ResourceAddress,
-				ID: resourceID,
+				ID: finalMappedResource.ResourceID,
 			}
 			importBlocks = append(importBlocks, importBlock)
 		}

--- a/analyzer/mapping.go
+++ b/analyzer/mapping.go
@@ -132,6 +132,10 @@ func (importer *MappingClient) mapResourcesFromGraphToPlan(graphResources []*typ
 		}
 
 		for _, graphResource := range graphResources {
+			// Prefilter by Azure resource type when subtype is known (e.g., azapi_resource)
+			if resource.SubType != "" && !strings.EqualFold(graphResource.Type, resource.SubType) {
+				continue
+			}
 			if resource.ResourceNameMatchType == types.NameMatchTypeExact && strings.ToLower(graphResource.Name) == strings.ToLower(resource.ResourceName) {
 				resource.MappedResources = append(resource.MappedResources, graphResource)
 			}
@@ -141,6 +145,10 @@ func (importer *MappingClient) mapResourcesFromGraphToPlan(graphResources []*typ
 			}
 
 			if resource.ResourceNameMatchType == types.NameMatchTypeIDEndsWith && strings.HasSuffix(strings.ToLower(graphResource.ID), strings.ToLower(resource.ResourceName)) {
+				resource.MappedResources = append(resource.MappedResources, graphResource)
+			}
+
+			if resource.ResourceNameMatchType == types.NameMatchTypeIDExact && strings.EqualFold(graphResource.ID, resource.ResourceName) {
 				resource.MappedResources = append(resource.MappedResources, graphResource)
 			}
 		}

--- a/terraform/plan_test.go
+++ b/terraform/plan_test.go
@@ -1,0 +1,116 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/azure/terraform-state-importer/types"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NameFormatAppliedBySubType(t *testing.T) {
+	logger := logrus.New()
+	pc := &PlanClient{
+		PropertyMappings: []types.PropertyMapping{},
+		NameFormats: []types.NameFormat{
+			{
+				Type:                "Microsoft.Authorization/policyAssignments",
+				SubType:             "",
+				NameFormat:          "%s/providers/Microsoft.Authorization/policyAssignments/%s",
+				NameMatchType:       types.NameMatchTypeIDEndsWith,
+				NameFormatArguments: []string{"parent_id", "name"},
+			},
+		},
+		Logger: logger,
+	}
+
+	res := &types.PlanResource{
+		Address: "addr1",
+		Type:    "azapi_resource",
+		SubType: "Microsoft.Authorization/policyAssignments",
+		Properties: map[string]any{
+			"parent_id": "/providers/Microsoft.Management/managementGroups/alz-aks-public",
+			"name":      "Allow-Vnet-Peering",
+		},
+	}
+
+	out := pc.mapPropertiesAndNames([]*types.PlanResource{res})
+	assert.Equal(t, 1, len(out))
+	want := "/providers/Microsoft.Management/managementGroups/alz-aks-public/providers/Microsoft.Authorization/policyAssignments/Allow-Vnet-Peering"
+	assert.Equal(t, want, out[0].ResourceName)
+	assert.Equal(t, types.NameMatchTypeIDEndsWith, out[0].ResourceNameMatchType)
+}
+
+func Test_NameFormat_PreferExactSubTypeOverType(t *testing.T) {
+	logger := logrus.New()
+	pc := &PlanClient{
+		PropertyMappings: []types.PropertyMapping{},
+		NameFormats: []types.NameFormat{
+			// Broader Type match
+			{
+				Type:                "azapi_resource",
+				SubType:             "Microsoft.Authorization/policyAssignments",
+				NameFormat:          "BROADER:%s/%s",
+				NameMatchType:       types.NameMatchTypeIDEndsWith,
+				NameFormatArguments: []string{"parent_id", "name"},
+			},
+			// Exact SubType match
+			{
+				Type:                "Microsoft.Authorization/policyAssignments",
+				SubType:             "",
+				NameFormat:          "EXACT:%s/%s",
+				NameMatchType:       types.NameMatchTypeIDEndsWith,
+				NameFormatArguments: []string{"parent_id", "name"},
+			},
+		},
+		Logger: logger,
+	}
+
+	res := &types.PlanResource{
+		Address: "addr1",
+		Type:    "azapi_resource",
+		SubType: "Microsoft.Authorization/policyAssignments",
+		Properties: map[string]any{
+			"parent_id": "/p",
+			"name":      "n",
+		},
+	}
+
+	out := pc.mapPropertiesAndNames([]*types.PlanResource{res})
+	assert.Equal(t, 1, len(out))
+	// Expect exact SubType match chosen first
+	assert.Equal(t, "EXACT:/p/n", out[0].ResourceName)
+}
+
+func Test_NameFormat_IDExact_ForPolicyDefinitions(t *testing.T) {
+	logger := logrus.New()
+	pc := &PlanClient{
+		PropertyMappings: []types.PropertyMapping{},
+		NameFormats: []types.NameFormat{
+			{
+				Type:                "Microsoft.Authorization/policyDefinitions",
+				SubType:             "",
+				NameFormat:          "%s/providers/Microsoft.Authorization/policyDefinitions/%s",
+				NameMatchType:       types.NameMatchTypeIDExact,
+				NameFormatArguments: []string{"parent_id", "name"},
+			},
+		},
+		Logger: logger,
+	}
+
+	res := &types.PlanResource{
+		Address: "addr1",
+		Type:    "azapi_resource",
+		SubType: "Microsoft.Authorization/policyDefinitions",
+		Properties: map[string]any{
+			"parent_id": "/providers/Microsoft.Management/managementGroups/alz",
+			"name":      "Enforce-Tag",
+		},
+	}
+
+	out := pc.mapPropertiesAndNames([]*types.PlanResource{res})
+	assert.Equal(t, 1, len(out))
+	want := "/providers/Microsoft.Management/managementGroups/alz/providers/Microsoft.Authorization/policyDefinitions/Enforce-Tag"
+	assert.Equal(t, want, out[0].ResourceName)
+	assert.Equal(t, types.NameMatchTypeIDExact, out[0].ResourceNameMatchType)
+}

--- a/types/terraform.go
+++ b/types/terraform.go
@@ -20,4 +20,5 @@ const (
 	NameMatchTypeExact      NameMatchType = "Exact"
 	NameMatchTypeIDContains NameMatchType = "IDContains"
 	NameMatchTypeIDEndsWith NameMatchType = "IDEndsWith"
+	NameMatchTypeIDExact    NameMatchType = "IDExact"
 )


### PR DESCRIPTION
Got some good help from Copilot to implement a potential fix to issue Azure/Azure-Landing-Zones#1449 

# Deterministic Matching for Azure Policy Artifacts

Improves precision when mapping Terraform azapi_resource policy artifacts to Azure Resource Graph resources by eliminating cross-type false matches and enabling exact ID matching.

**Problem**

Policy artifacts (assignments, definitions, set definitions) with identical names across management groups caused MultipleResourceIDs issues. The mapper didn't filter by Azure resource type before matching, causing cross-type pollution.

**Solution**

Type prefiltering: When a resource has a `SubType`, only match graph resources with that exact Azure type (case-insensitive)
Subtype-aware name formats: `nameFormats` now match on `SubType` with deterministic precedence (exact SubType → Type+SubType → Type alone)
IDExact match type: New optional match mode for exact full-ID equality when nameFormats construct complete resource IDs

**Changes**
* mapping.go: Added type prefilter and IDExact matching branch
* plan.go: Implemented two-pass nameFormat selection with SubType precedence
* terraform.go: Added `NameMatchTypeIDExact` constant
* mapping_test.go: 4 new tests validating type isolation and exact matching
* plan_test.go: 3 new tests verifying nameFormat selection logic

**Testing**
TDD approach: Tests written first, minimal implementation added to pass. All existing tests remain passing; no breaking changes.

**Backward Compatibility**
* Type prefilter only activates when `SubType` is present
* Existing nameFormat configs for Microsoft.Authorization/* types now work correctly with azapi_resource
IDExact is opt-in via configuration